### PR TITLE
refactor: create AuthService for authentication and restructure DTOs …

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -106,6 +106,30 @@
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>2.5.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>5.4.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.9.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<version>5.4.0</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.erp</groupId>
+			<artifactId>maisPraTi</artifactId>
+			<version>0.0.1-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/com/erp/maisPraTi/controller/AuthController.java
+++ b/backend/src/main/java/com/erp/maisPraTi/controller/AuthController.java
@@ -1,43 +1,26 @@
 package com.erp.maisPraTi.controller;
 
 import com.erp.maisPraTi.dto.login.LoginRequest;
-import com.erp.maisPraTi.security.JwtTokenProvider;
-import com.erp.maisPraTi.service.UserService;
-import com.erp.maisPraTi.service.exceptions.AuthenticationUserException;
+import com.erp.maisPraTi.dto.login.LoginResponse;
+import com.erp.maisPraTi.service.AuthService;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping
+@RequestMapping("/api")
 public class AuthController {
 
-    private final AuthenticationManager authenticationManager;
-    private final JwtTokenProvider jwtTokenProvider;
-    private final UserService userService;
-    private final BCryptPasswordEncoder passwordEncoder;
+    @Autowired
+    private AuthService service;
 
-    public AuthController(AuthenticationManager authenticationManager, JwtTokenProvider jwtTokenProvider, UserService userService, BCryptPasswordEncoder passwordEncoder) {
-        this.authenticationManager = authenticationManager;
-        this.jwtTokenProvider = jwtTokenProvider;
-        this.userService = userService;
-        this.passwordEncoder = passwordEncoder;
-    }
-
-    @PostMapping("auth")
-    public ResponseEntity<String> login (@RequestBody LoginRequest loginRequest){
-        try {
-            Authentication authentication = authenticationManager.authenticate(
-                    new UsernamePasswordAuthenticationToken(loginRequest.getEmail(), loginRequest.getPassword())
-            );
-            String token = jwtTokenProvider.generateToken(authentication);
-            return ResponseEntity.ok().body(token);
-        } catch (AuthenticationUserException error) {
-            throw new AuthenticationUserException("Credenciais inválidas.");
-        }
+    @PostMapping("/login")
+    public ResponseEntity<String> login (@RequestBody LoginRequest request){
+        LoginResponse response = service.login(request);
+        return ResponseEntity.ok().body(response.getToken());
     }
 
 }

--- a/backend/src/main/java/com/erp/maisPraTi/controller/ClientController.java
+++ b/backend/src/main/java/com/erp/maisPraTi/controller/ClientController.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 
 @RestController
 @CrossOrigin(origins = "http://localhost:5173")
-@RequestMapping(value = "/clientes")
+@RequestMapping(value = "api/clientes")
 public class ClientController {
 
     @Autowired

--- a/backend/src/main/java/com/erp/maisPraTi/controller/ProductController.java
+++ b/backend/src/main/java/com/erp/maisPraTi/controller/ProductController.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 
 @RestController
 @CrossOrigin(origins = "http://localhost:5173")
-@RequestMapping(value = "/produtos")
+@RequestMapping(value = "api/produtos")
 public class ProductController {
 
     @Autowired

--- a/backend/src/main/java/com/erp/maisPraTi/controller/SupplierController.java
+++ b/backend/src/main/java/com/erp/maisPraTi/controller/SupplierController.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 
 @RestController
 @CrossOrigin(origins = "http://localhost:5173")
-@RequestMapping(value = "/fornecedores")
+@RequestMapping(value = "/api/fornecedores")
 public class SupplierController {
 
     @Autowired

--- a/backend/src/main/java/com/erp/maisPraTi/controller/UserController.java
+++ b/backend/src/main/java/com/erp/maisPraTi/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.erp.maisPraTi.controller;
 
 import com.erp.maisPraTi.dto.users.UserDto;
+import com.erp.maisPraTi.dto.users.UserInsertDto;
 import com.erp.maisPraTi.dto.users.UserUpdateDto;
 import com.erp.maisPraTi.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -17,7 +18,7 @@ import java.net.URI;
 import java.util.Optional;
 
 @RestController
-@RequestMapping("/usuarios")
+@RequestMapping("/api/usuarios")
 public class UserController {
 
     @Autowired
@@ -29,8 +30,8 @@ public class UserController {
             @ApiResponse(responseCode = "400", description = "Dados inválidos")
     })
     @PostMapping
-    public ResponseEntity<UserDto> insert(@RequestBody UserDto userDto){
-        UserDto newUserDto = userService.insert(userDto);
+    public ResponseEntity<UserDto> insert(@RequestBody UserInsertDto userInsertDto){
+        UserDto newUserDto = userService.insert(userInsertDto);
         URI uri = ServletUriComponentsBuilder
                 .fromCurrentRequest()
                 .path("/{id}")

--- a/backend/src/main/java/com/erp/maisPraTi/dto/partyDto/suppliers/SupplierDto.java
+++ b/backend/src/main/java/com/erp/maisPraTi/dto/partyDto/suppliers/SupplierDto.java
@@ -1,6 +1,7 @@
 package com.erp.maisPraTi.dto.partyDto.suppliers;
 
 import com.erp.maisPraTi.dto.partyDto.PartyDto;
+import com.erp.maisPraTi.model.Product;
 import com.erp.maisPraTi.service.validations.DocumentsValid;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
@@ -20,6 +21,6 @@ public class SupplierDto extends PartyDto {
     @JsonProperty(access = JsonProperty.Access.READ_ONLY)
     private Long id;
 
-    private List<Long> productIds;
+    private List<Product> products;
 
 }

--- a/backend/src/main/java/com/erp/maisPraTi/dto/partyDto/suppliers/SupplierUpdateDto.java
+++ b/backend/src/main/java/com/erp/maisPraTi/dto/partyDto/suppliers/SupplierUpdateDto.java
@@ -1,6 +1,7 @@
 package com.erp.maisPraTi.dto.partyDto.suppliers;
 
 import com.erp.maisPraTi.dto.partyDto.PartyDto;
+import com.erp.maisPraTi.model.Product;
 import com.erp.maisPraTi.service.validations.DocumentsValid;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -16,6 +17,6 @@ import java.util.List;
 @NoArgsConstructor
 public class SupplierUpdateDto extends PartyDto {
 
-    private List<Long> productIds;
+    private List<Product> products;
 
 }

--- a/backend/src/main/java/com/erp/maisPraTi/dto/users/UserInsertDto.java
+++ b/backend/src/main/java/com/erp/maisPraTi/dto/users/UserInsertDto.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class UserUpdateDto extends UserDto{
+public class UserInsertDto extends UserDto{
 
     private String password;
 }

--- a/backend/src/main/java/com/erp/maisPraTi/security/JwtRequestFilter.java
+++ b/backend/src/main/java/com/erp/maisPraTi/security/JwtRequestFilter.java
@@ -1,8 +1,7 @@
 package com.erp.maisPraTi.security;
 
 import com.erp.maisPraTi.security.exceptions.StandardErrorAuth;
-import com.erp.maisPraTi.service.UserService;
-import com.erp.maisPraTi.service.exceptions.JwtTokenException;
+import com.erp.maisPraTi.service.UserDetailsServiceImpl;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.FilterChain;
@@ -27,7 +26,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
     private JwtTokenProvider jwtTokenProvider;
 
     @Autowired
-    private UserService userService;
+    private UserDetailsServiceImpl userService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,

--- a/backend/src/main/java/com/erp/maisPraTi/security/JwtTokenProvider.java
+++ b/backend/src/main/java/com/erp/maisPraTi/security/JwtTokenProvider.java
@@ -2,13 +2,11 @@ package com.erp.maisPraTi.security;
 
 import com.erp.maisPraTi.model.Role;
 import com.erp.maisPraTi.model.User;
-import io.jsonwebtoken.security.Keys;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
@@ -29,8 +27,6 @@ public class JwtTokenProvider {
 
     @Value("${jwt.expiration}")
     private Long jwtExpiration;
-
-    private static Logger logger = LoggerFactory.getLogger(JwtTokenProvider.class);
 
     //Metodo para gerar uma chave secreta do tipo SecretKey a partir da string do jwtSecret
     private SecretKey getSigningKey() {

--- a/backend/src/main/java/com/erp/maisPraTi/service/AuthService.java
+++ b/backend/src/main/java/com/erp/maisPraTi/service/AuthService.java
@@ -1,0 +1,36 @@
+package com.erp.maisPraTi.service;
+
+import com.erp.maisPraTi.dto.login.LoginRequest;
+import com.erp.maisPraTi.dto.login.LoginResponse;
+import com.erp.maisPraTi.security.JwtTokenProvider;
+import com.erp.maisPraTi.service.exceptions.AuthenticationUserException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+
+    @Autowired
+    private AuthenticationManager authenticationManager;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    public LoginResponse login(LoginRequest request){
+        try {
+            Authentication authentication = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword())
+            );
+            LoginResponse response = new LoginResponse();
+            String token = jwtTokenProvider.generateToken(authentication);
+            response.setToken(token);
+            return response;
+        } catch (AuthenticationUserException error) {
+            throw new AuthenticationUserException("Credenciais inválidas.");
+        }
+    }
+
+}

--- a/backend/src/main/java/com/erp/maisPraTi/service/UserDetailsServiceImpl.java
+++ b/backend/src/main/java/com/erp/maisPraTi/service/UserDetailsServiceImpl.java
@@ -1,0 +1,25 @@
+package com.erp.maisPraTi.service;
+
+import com.erp.maisPraTi.model.User;
+import com.erp.maisPraTi.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserDetailsServiceImpl implements UserDetailsService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email);
+        if(user == null) {
+            throw new UsernameNotFoundException("Usuário não encontrado: " + email);
+        }
+        return user;
+    }
+}

--- a/backend/src/main/java/com/erp/maisPraTi/service/exceptions/AuthenticationUserException.java
+++ b/backend/src/main/java/com/erp/maisPraTi/service/exceptions/AuthenticationUserException.java
@@ -1,5 +1,6 @@
 package com.erp.maisPraTi.service.exceptions;
 
+
 public class AuthenticationUserException extends RuntimeException{
     public AuthenticationUserException(String message) {
         super(message);

--- a/backend/src/main/java/com/erp/maisPraTi/service/exceptions/UsernameNotFoundException.java
+++ b/backend/src/main/java/com/erp/maisPraTi/service/exceptions/UsernameNotFoundException.java
@@ -1,7 +1,0 @@
-package com.erp.maisPraTi.service.exceptions;
-
-public class UsernameNotFoundException extends RuntimeException{
-    public UsernameNotFoundException(String message) {
-        super(message);
-    }
-}

--- a/backend/src/main/java/com/erp/maisPraTi/util/CNPJValidator.java
+++ b/backend/src/main/java/com/erp/maisPraTi/util/CNPJValidator.java
@@ -4,12 +4,12 @@ public class CNPJValidator {
 
     public static boolean validarCNPJ(String cnpj) {
 
+        // Teste caracteres especiais (diferentes de numericos)
+        if(cnpj.matches(".*[^0-9./-].*"))
+            return false;
+
         // Remove caracteres não numéricos
         cnpj = cnpj.replaceAll("[^0-9]", "");
-
-        // Teste caracteres especiais (diferentes de numericos)
-        if(!cnpj.matches("\\d+"))
-            return false;
 
         // Verifica se o CNPJ tem 14 dígitos
         if (cnpj.length() != 14)

--- a/backend/src/main/resources/application-test.properties
+++ b/backend/src/main/resources/application-test.properties
@@ -3,9 +3,9 @@ spring.datasource.url=jdbc:h2:mem:db;DB_CLOSE_DELAY=-1
 spring.datasource.username=sa
 spring.datasource.password=
 
-spring.h2.console.enabled=false
+spring.h2.console.enabled=true
 spring.jpa.show-sql=false
-spring.h2.console.path=/h2-console
+spring.h2.console.path=/api/h2-console
 spring.jpa.hibernate.ddl-auto=create-drop
 
 spring.jpa.properties.hibernate.format_sql = true

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -10,10 +10,10 @@ jwt.expiration=${JWT_EXPIRATION:86400000}
 jwt.issuerUri=http://localhost:8080
 
 # Open Api - Swagger
-springdoc.api-docs.path=/api-docs
+springdoc.api-docs.path=/api/docs
 springdoc.swagger-ui.operationsSorter=alpha
 springdoc.swagger-ui.enable=true
-springdoc.swagger-ui.path=/documentation.html
+springdoc.swagger-ui.path=/api/documentation.html
 springdoc.api-docs.version=OPENAPI_3_0
 spring.jpa.hibernate.ddl-auto=none
 server.forward-headers-strategy=framework

--- a/backend/src/test/java/com/erp/maisPraTi/fixture/LoginFixture.java
+++ b/backend/src/test/java/com/erp/maisPraTi/fixture/LoginFixture.java
@@ -1,0 +1,4 @@
+package com.erp.maisPraTi.fixture;
+
+public class LoginFixture {
+}

--- a/backend/src/test/java/com/erp/maisPraTi/fixture/UserFixture.java
+++ b/backend/src/test/java/com/erp/maisPraTi/fixture/UserFixture.java
@@ -1,0 +1,4 @@
+package com.erp.maisPraTi.fixture;
+
+public class UserFixture {
+}

--- a/backend/src/test/java/com/erp/maisPraTi/service/UserServiceTest.java
+++ b/backend/src/test/java/com/erp/maisPraTi/service/UserServiceTest.java
@@ -1,0 +1,4 @@
+package com.erp.maisPraTi.service;
+
+public class UserServiceTest {
+}


### PR DESCRIPTION
- Separação do UserDetails em uma service separada
- Retirada da responsabilidade de autenticação da controller e passada para AuthService
- Reestruturação dos DTOs para criação de clientes e fornecedores pois os mesmos dividem a maioria dos atributos
- Ajuste validação de CNPJ e CPF para reutilizar a validation em todas as situações (criação e atualização) de clientes e fornecedores
- Alteração de rota de login, de /auth para /login
- Inclusão de /api no inicio de todas as rotas: localhost:8080/api/login (exemplo rota de login)
- Correção de service para criar e atualizar usuários, não estava criptografando a senha para o BD